### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# DEPRECATION NOTICE
+
+This image was created at a time where `netdata/netdata` docker image was
+not capable of running as an arbitrary user.
+
+With the merge of [PR#6543](https://github.com/netdata/netdata/pull/6543)
+this is now in the base image, so this image is not necessary anymore.
+
+We will archive this repository and delete the `vshn/netdata-openshift`
+docker image on Docker Hub on **August 1, 2020**.
+
 # netdata-openshift
 
 Docker image derived from official `netdata/netdata` image, but runs as


### PR DESCRIPTION
We have merged https://github.com/vshn/netdata-web-log/pull/4, so we can get rid of this repo and image.

Date of 1st August is just a proposal, open for discussion.